### PR TITLE
Diffs to make ParseKit build with Xcode 3.2.5

### DIFF
--- a/ParseKit.xcodeproj/project.pbxproj
+++ b/ParseKit.xcodeproj/project.pbxproj
@@ -2673,7 +2673,14 @@
 			isa = PBXProject;
 			buildConfigurationList = 1DEB91B108733DA50010E9CD /* Build configuration list for PBXProject "ParseKit" */;
 			compatibilityVersion = "Xcode 2.4";
+			developmentRegion = English;
 			hasScannedForEncodings = 1;
+			knownRegions = (
+				English,
+				Japanese,
+				French,
+				German,
+			);
 			mainGroup = 0867D691FE84028FC02AAC07 /* TODParseKit */;
 			productRefGroup = 034768DFFF38A50411DB9C8B /* Products */;
 			projectDirPath = "";
@@ -3308,7 +3315,7 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				PREBINDING = NO;
-				SDKROOT = /Developer/SDKs/MacOSX10.5.sdk;
+				SDKROOT = macosx;
 			};
 			name = Debug;
 		};
@@ -3318,7 +3325,7 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				PREBINDING = NO;
-				SDKROOT = /Developer/SDKs/MacOSX10.5.sdk;
+				SDKROOT = macosx;
 			};
 			name = Release;
 		};
@@ -3608,7 +3615,7 @@
 				);
 				PREBINDING = NO;
 				PRODUCT_NAME = Tests;
-				SDKROOT = "";
+				SDKROOT = macosx;
 				USER_HEADER_SEARCH_PATHS = "";
 				WARNING_CFLAGS = "";
 				WRAPPER_EXTENSION = octest;
@@ -3652,7 +3659,7 @@
 				);
 				PREBINDING = NO;
 				PRODUCT_NAME = Tests;
-				SDKROOT = "";
+				SDKROOT = macosx;
 				WARNING_CFLAGS = "";
 				WRAPPER_EXTENSION = octest;
 				ZERO_LINK = NO;
@@ -3672,7 +3679,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				PREBINDING = NO;
 				PRODUCT_NAME = parsekit;
-				SDKROOT = iphoneos3.0;
+				SDKROOT = iphoneos;
 			};
 			name = Debug;
 		};
@@ -3690,7 +3697,7 @@
 				OTHER_LDFLAGS = "";
 				PREBINDING = NO;
 				PRODUCT_NAME = parsekit;
-				SDKROOT = iphoneos3.0;
+				SDKROOT = iphoneos;
 				ZERO_LINK = NO;
 			};
 			name = Release;

--- a/demoapp/TDSourceCodeTextView.m
+++ b/demoapp/TDSourceCodeTextView.m
@@ -81,7 +81,7 @@
     NSRange visibleGlyphRange = [layoutMgr glyphRangeForBoundingRect:boundingRect inTextContainer:self.textContainer];
         
     NSUInteger index = visibleGlyphRange.location;
-    NSUInteger length = index + [visibleGlyphRange length];
+    NSUInteger length = index + visibleGlyphRange.length;
 
     (*outStart) = [self lineNumberForIndex:index + 1];
     

--- a/include/ParseKit/PKAssembly.h
+++ b/include/ParseKit/PKAssembly.h
@@ -84,3 +84,10 @@
 */
 @property (nonatomic, retain) id target;
 @end
+
+
+@interface PKAssembly (Subclassing)
+@property (nonatomic, readwrite, retain) NSString *defaultDelimiter;
+@property (nonatomic, readonly) NSUInteger length;
+@end
+


### PR DESCRIPTION
Fairly straightforward, I hope. Changes to the project file to reference the current SDK, and a couple of errors caught by the compiler.
