### PR TITLE
Disable NSTextView substitutions.

### DIFF
--- a/ParserGenApp/PGDocument.m
+++ b/ParserGenApp/PGDocument.m
@@ -72,6 +72,7 @@
 - (void)windowControllerDidLoadNib:(NSWindowController *)wc {
     [super windowControllerDidLoadNib:wc];
     
+    [_textView setEnabledTextCheckingTypes:0];
     [_textView setFont:[NSFont fontWithName:@"Monaco" size:12.0]];
 }
 


### PR DESCRIPTION
Substitutions like smart quotes mangle both typed and pasted grammars,
causing the app to crash on what would otherwise be valid input.
